### PR TITLE
Tox config + test issues

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source =
+    bootstrap4
+
+[html]
+directory = reports/htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ local_settings.py
 
 # pyenv
 .python-version
+reports

--- a/bootstrap4/tests.py
+++ b/bootstrap4/tests.py
@@ -725,3 +725,9 @@ class PaginatorTest(TestCase):
 
         res = self.bootstrap_pagination(p.page(2), extra='url="/projects/?page=3#id"')
         self.assertTrue('/projects/?page=1#id' in res)
+
+        res = self.bootstrap_pagination(p.page(2), extra='url="/projects/?page=3" extra="id=20"')
+        self.assertTrue(
+            '/projects/?page=1&id=20' in res or
+            '/projects/?id=20&page=1' in res
+        )

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -53,11 +53,6 @@ bootstrap_button
 .. autofunction:: bootstrap4.templatetags.bootstrap4.bootstrap_button
 
 
-bootstrap_icon
-~~~~~~~~~~~~~~
-
-.. autofunction:: bootstrap4.templatetags.bootstrap4.bootstrap_icon
-
 bootstrap_alert
 ~~~~~~~~~~~~~~~
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,14 @@ envlist =
     py27-{111}
     py34-{111}
     py35-{111}
-    py36-{111}
     py36-{111,master}
     flake8
     docs
 
 [testenv]
-commands = coverage run --append --source='.' manage.py test -v1 --noinput
+commands =
+    coverage run --source=bootstrap4 manage.py test -v1 --noinput
+    coverage html
 deps =
     coverage
     111: Django>=1.11,<1.12
@@ -29,7 +30,7 @@ max-line-length = 120
 [testenv:docs]
 changedir = docs
 deps =
-    django>=1.8
+    Django>=1.11,<1.12
     sphinx
     sphinx_rtd_theme
 commands = sphinx-build -b html -d _build/doctrees . _build/html


### PR DESCRIPTION
 - Remove duplicated testenv in tox.ini
 - generate coverage report in tox.ini
 - remove bootstrap_icon from docs to fix warning
 - add another test case for the paginator tag to test the `extra` template tag argument.