### PR TITLE
Allow input group addons for NumberInput type

### DIFF
--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -8,7 +8,7 @@ except RuntimeError:
     ReadOnlyPasswordHashWidget = None
 
 from django.forms import (
-    TextInput, DateInput, FileInput, CheckboxInput, MultiWidget,
+    TextInput, DateInput, FileInput, NumberInput, CheckboxInput, MultiWidget,
     ClearableFileInput, Select, RadioSelect, CheckboxSelectMultiple
 )
 from django.forms.widgets import SelectDateWidget
@@ -398,7 +398,8 @@ class FieldRenderer(BaseRenderer):
         return html
 
     def make_input_group(self, html):
-        if (self.addon_before or self.addon_after) and isinstance(self.widget, (TextInput, DateInput, Select)):
+        allowed_widget_types = (TextInput, DateInput, NumberInput, Select)
+        if (self.addon_before or self.addon_after) and isinstance(self.widget, allowed_widget_types):
             before = '<span class="{input_class}">{addon}</span>'.format(
                 input_class=self.addon_before_class, addon=self.addon_before) if self.addon_before else ''
             after = '<span class="{input_class}">{addon}</span>'.format(


### PR DESCRIPTION
Bootstrap 4 allows before and after addons to be attached to more input types than before. (And it also allows multiple addons to be stacked on a single input control.) This PR just adds support attaching addons to widgets of type `NumberInput`.  