### PR TITLE
Fix: stylesheet-html must have 'href' attribute

### DIFF
--- a/bootstrap4/tests.py
+++ b/bootstrap4/tests.py
@@ -245,6 +245,23 @@ class MediaTest(TestCase):
             ' rel="stylesheet">',
             res
         )
+        # Theme
+        self.assertInHTML(
+            '<link rel="stylesheet" href="//example.com/theme.css">',
+            res
+        )
+
+    def test_bootstrap_css_from_base_url(self):
+        with self.settings(BOOTSTRAP4={'base_url': '//example.com/', 'css_url': None}):
+            res = render_template_with_form('{% bootstrap_css_url %}').strip()
+            self.assertEqual(res, '//example.com/css/bootstrap.min.css')
+            res = render_template_with_form('{% bootstrap_css %}').strip()
+            self.assertInHTML(
+                '<link'
+                ' href="//example.com/css/bootstrap.min.css"'
+                ' rel="stylesheet">',
+                res
+            )
 
     def test_settings_filter(self):
         res = render_template_with_form('{{ "required_css_class"|bootstrap_setting }}')

--- a/bootstrap4/utils.py
+++ b/bootstrap4/utils.py
@@ -115,7 +115,7 @@ def render_link_tag(url, rel='stylesheet', media=None):
     """
     Build a link tag
     """
-    url_dict = sanitize_url_dict(url)
+    url_dict = sanitize_url_dict(url, url_attr='href')
     url_dict.setdefault('href', url_dict.pop('url', None))
     url_dict['rel'] = rel
     if media:
@@ -170,10 +170,10 @@ def url_replace_param(url, name, value):
     ]))
 
 
-def sanitize_url_dict(url):
+def sanitize_url_dict(url, url_attr='src'):
     """
     Sanitize url dict as used in django-bootstrap4 settings
     """
     if isinstance(url, six.string_types):
-        return dict(src=url)
+        return {url_attr: url}
     return url


### PR DESCRIPTION
When using `{% bootstrap_css %}` if  settings.py has 'theme_url', the link tag for theme_url is generated wrong.
Because `sanitize_url_dict()` always generate dict(src=url) from URL string.
But in <link> tag, URL resource path must be in `href` attribute.


Except:

 ```html
<link ref="stylesheet" href="/static/css/theme.css" >
```

Actually:

```html
<link ref="stylesheet" src="/static/css/theme.css">
```


This PR fixes it.