### PR TITLE
Bootstrap4 beta

### DIFF
--- a/bootstrap4/bootstrap.py
+++ b/bootstrap4/bootstrap.py
@@ -8,10 +8,10 @@ from django.conf import settings
 # Default settings
 
 BOOTSTRAP4_DEFAULTS = {
-    'base_url': None,  # '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/'
+    'base_url': None,  # '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/'
     'css_url': {
-        'href': "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css",
-        'integrity': "sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ",
+        'href': "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css",
+        'integrity': "sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M",
         'crossorigin': "anonymous",
     },
     'theme_url': None,
@@ -26,8 +26,8 @@ BOOTSTRAP4_DEFAULTS = {
 
     },
     'javascript_url': {
-        'url': "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js",
-        'integrity': "sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn",
+        'url': "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js",
+        'integrity': "sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1",
         'crossorigin': "anonymous",
     },
     'javascript_in_head': False,

--- a/bootstrap4/bootstrap.py
+++ b/bootstrap4/bootstrap.py
@@ -25,6 +25,12 @@ BOOTSTRAP4_DEFAULTS = {
         'crossorigin': "anonymous",
 
     },
+    'popper_url': {
+        'url': "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.5/umd/popper.min.js",
+        'integrity': "sha256-jpW4gXAhFvqGDD5B7366rIPD7PDbAmqq4CO0ZnHbdM4=",
+        'crossorigin': "anonymous",
+
+    },
     'javascript_url': {
         'url': "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js",
         'integrity': "sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1",
@@ -84,6 +90,13 @@ def tether_url():
     Return the full url to the Bootstrap JavaScript file
     """
     return get_bootstrap_setting('tether_url')
+
+
+def popper_url():
+    """
+    Return the full url to Popper file
+    """
+    return get_bootstrap_setting('popper_url')
 
 
 def javascript_url():

--- a/bootstrap4/templatetags/bootstrap4.py
+++ b/bootstrap4/templatetags/bootstrap4.py
@@ -10,7 +10,7 @@ from django.utils import six
 from django.utils.safestring import mark_safe
 from django.utils.six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
-from ..bootstrap import css_url, get_bootstrap_setting, javascript_url, jquery_url, tether_url, theme_url
+from ..bootstrap import css_url, get_bootstrap_setting, javascript_url, jquery_url, popper_url, tether_url, theme_url
 from ..components import render_alert
 from ..forms import (render_button, render_field, render_field_and_label, render_form, render_form_errors,
                      render_form_group, render_formset, render_formset_errors, render_label)
@@ -110,6 +110,30 @@ def bootstrap_tether_url():
         {% bootstrap_tether_url %}
     """
     return tether_url()
+
+
+@register.simple_tag
+def bootstrap_popper_url():
+    """
+    Return the full url to the Popper plugin to use
+
+    Default value: ``None``
+
+    This value is configurable, see Settings section
+
+    **Tag name**::
+
+        bootstrap_popper_url
+
+    **Usage**::
+
+        {% bootstrap_popper_url %}
+
+    **Example**::
+
+        {% bootstrap_popper_url %}
+    """
+    return popper_url()
 
 
 @register.simple_tag
@@ -290,6 +314,9 @@ def bootstrap_javascript(jquery=None):
     tether = bootstrap_tether_url()
     if tether:
         javascript_tags.append(render_script_tag(tether))
+    popper = bootstrap_popper_url()
+    if popper:
+        javascript_tags.append(render_script_tag(popper))
     js = bootstrap_javascript_url()
     if js:
         javascript_tags.append(render_script_tag(js))

--- a/bootstrap4/tests.py
+++ b/bootstrap4/tests.py
@@ -226,6 +226,17 @@ class MediaTest(TestCase):
             '></script>',
             res
         )
+
+        # Popper
+        self.assertInHTML(
+            '<script'
+            ' src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.5/umd/popper.min.js"'
+            ' integrity="sha256-jpW4gXAhFvqGDD5B7366rIPD7PDbAmqq4CO0ZnHbdM4="'
+            ' crossorigin="anonymous"'
+            '></script>',
+            res
+        )
+
         # Bootstrap
         self.assertInHTML(
             '<script'

--- a/bootstrap4/tests.py
+++ b/bootstrap4/tests.py
@@ -229,8 +229,8 @@ class MediaTest(TestCase):
         # Bootstrap
         self.assertInHTML(
             '<script'
-            ' src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js"'
-            ' integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn"'
+            ' src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js"'
+            ' integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1"'
             ' crossorigin="anonymous"'
             '></script>',
             res
@@ -240,8 +240,8 @@ class MediaTest(TestCase):
         res = render_template_with_form('{% bootstrap_css %}').strip()
         self.assertInHTML(
             '<link crossorigin="anonymous"'
-            ' href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"'
-            ' integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ"'
+            ' href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css"'
+            ' integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" '
             ' rel="stylesheet">',
             res
         )


### PR DESCRIPTION
[Announce from The Bootstrap Blog](https://blog.getbootstrap.com/2017/08/10/bootstrap-4-beta/)

Changes:

- Modify bootstrap URLs from v4-alpha to v4-beta
- Add Popper.js section for bootstrap dropdown for v4-beta