### PR TITLE
Handle changes of widgets inheritance

### DIFF
--- a/bootstrap4/forms.py
+++ b/bootstrap4/forms.py
@@ -2,7 +2,8 @@
 from __future__ import unicode_literals
 
 from django.contrib.admin.widgets import AdminFileWidget
-from django.forms import HiddenInput, FileInput, CheckboxSelectMultiple, Textarea, TextInput, PasswordInput
+from django.forms import HiddenInput, FileInput, CheckboxSelectMultiple,\
+    TextInput, Textarea, NumberInput, EmailInput, URLInput, PasswordInput
 from django.forms.widgets import CheckboxInput
 from django.utils.safestring import mark_safe
 

--- a/bootstrap4/forms.py
+++ b/bootstrap4/forms.py
@@ -170,4 +170,5 @@ def is_widget_with_placeholder(widget):
     """
     # PasswordInput inherits from Input in Django 1.4.
     # It was changed to inherit from TextInput in 1.5.
-    return isinstance(widget, (TextInput, Textarea, PasswordInput))
+    # NumberInput, EmailInput, URLInput, PasswordInput switch from TextInput inheritance to Input inheritance in 1.11.
+    return isinstance(widget, (TextInput, Textarea, NumberInput, EmailInput, URLInput, PasswordInput))


### PR DESCRIPTION
In Django 1.11, NumberInput, EmailInput, URLInput, PasswordInput switch from TextInput inheritance to Input inheritance.
To be considered as widget with placeholder, I've updated is_widget_with_placeholder definition.