### PR TITLE
Fix removed help-block class on bootstrap4

### DIFF
--- a/bootstrap4/templates/bootstrap4/field_help_text_and_errors.html
+++ b/bootstrap4/templates/bootstrap4/field_help_text_and_errors.html
@@ -1,4 +1,4 @@
 {# Reverse the messages, so that errors are printed first #}
 {% for text in help_text_and_errors reversed %}
-    <div class="help-block">{{ text }}</div>
+    <div class="form-text text-muted">{{ text }}</div>
 {% endfor %}


### PR DESCRIPTION
Fix the missing class ```help-block```, removed on bootstrap4, replacing it for the recommended class on the bootstrap4 doc. See: https://v4-alpha.getbootstrap.com/components/forms/#help-text