### PR TITLE
Change form help text element from div to small

### DIFF
--- a/bootstrap4/templates/bootstrap4/field_help_text_and_errors.html
+++ b/bootstrap4/templates/bootstrap4/field_help_text_and_errors.html
@@ -3,5 +3,5 @@
     <div class="invalid-feedback">{{ text }}</div>
 {% endfor %}
 {% if field_help %}
-    <div class="form-text text-muted">{{ field_help }}</div>
+    <small class="form-text text-muted">{{ field_help }}</small>
 {% endif %}


### PR DESCRIPTION
Use `<small>` instead of `<div>` for form field help text.

Fixes #57 
