### PR TITLE
input-group changes in beta 3

### DIFF
--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -358,7 +358,7 @@ class FieldRenderer(BaseRenderer):
         )
 
     def fix_date_select_input(self, html):
-        div1 = '<div class="col-xs-4">'
+        div1 = '<div class="col-4">'
         div2 = '</div>'
         html = html.replace('<select', div1 + '<select')
         html = html.replace('</select>', '</select>' + div2)
@@ -380,7 +380,7 @@ class FieldRenderer(BaseRenderer):
 
         """
         # TODO This needs improvement
-        return '<div class="row bootstrap4-multi-input"><div class="col-xs-12">{html}</div></div>'.format(
+        return '<div class="row bootstrap4-multi-input"><div class="col-12">{html}</div></div>'.format(
             html=html
         )
 

--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -248,9 +248,9 @@ class FieldRenderer(BaseRenderer):
         self.addon_before = kwargs.get('addon_before', self.widget.attrs.pop('addon_before', ''))
         self.addon_after = kwargs.get('addon_after', self.widget.attrs.pop('addon_after', ''))
         self.addon_before_class = kwargs.get('addon_before_class',
-                                             self.widget.attrs.pop('addon_before_class', 'input-group-addon'))
+                                             self.widget.attrs.pop('addon_before_class', 'input-group-text'))
         self.addon_after_class = kwargs.get('addon_after_class',
-                                            self.widget.attrs.pop('addon_after_class', 'input-group-addon'))
+                                            self.widget.attrs.pop('addon_after_class', 'input-group-text'))
 
         # These are set in Django or in the global BOOTSTRAP4 settings, and
         # they can be overwritten in the template
@@ -404,16 +404,21 @@ class FieldRenderer(BaseRenderer):
             html = '<div class="checkbox">{content}</div>'.format(content=html)
         return html
 
+    def make_input_group_addon(self, inner_class, outer_class, content):
+        if not content:
+            return ''
+
+        content = '<span class="{input_class}">{addon}</span>'.format(
+            input_class=inner_class, addon=content) if inner_class else content
+
+        return '<div class="{addon_class}">{addon}</div>'.format(addon_class=outer_class, addon=content)
+
     def make_input_group(self, html):
         allowed_widget_types = (TextInput, PasswordInput, DateInput, NumberInput, Select)
         if (self.addon_before or self.addon_after) and isinstance(self.widget, allowed_widget_types):
-            before = '<span class="{input_class}">{addon}</span>'.format(
-                input_class=self.addon_before_class, addon=self.addon_before) if self.addon_before else ''
-            after = '<span class="{input_class}">{addon}</span>'.format(
-                input_class=self.addon_after_class, addon=self.addon_after) if self.addon_after else ''
             html = '<div class="input-group">{before}{html}{after}</div>'.format(
-                before=before,
-                after=after,
+                before=self.make_input_group_addon(self.addon_before_class, 'input-group-prepend', self.addon_before),
+                after=self.make_input_group_addon(self.addon_after_class, 'input-group-append', self.addon_after),
                 html=html
             )
         return html

--- a/bootstrap4/templatetags/bootstrap4.py
+++ b/bootstrap4/templatetags/bootstrap4.py
@@ -542,20 +542,24 @@ def bootstrap_field(*args, **kwargs):
 
             One of the following values:
 
-                * ``'input-group-addon'``
-                * ``'input-group-btn'``
+                * ``'input-group-text'``
+                * ``None``
 
-            :default: ``input-group-addon``
+            Set to None to disable the span inside the addon. (for use with buttons)
+
+            :default: ``input-group-text``
 
         addon_after_class
             Class used on the span when ``addon_after`` is used.
 
             One of the following values:
 
-                * ``'input-group-addon'``
-                * ``'input-group-btn'``
+                * ``'input-group-text'``
+                * ``None``
 
-            :default: ``input-group-addon``
+            Set to None to disable the span inside the addon. (for use with buttons)
+
+            :default: ``input-group-text``
 
         error_css_class
             CSS class used when the field has an error

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -475,6 +475,13 @@ class FieldTest(TestCase):
         self.assertIn('<div class="input-group-prepend">$</div>', res)
         self.assertIn('<div class="input-group-append">.00</div>', res)
 
+    def test_input_group_addon_empty(self):
+        res = render_template_with_form(
+            '{% bootstrap_field form.subject addon_before=None addon_after="" %}')  # noqa
+        self.assertNotIn('class="input-group"', res)
+        self.assertNotIn('<div class="input-group-prepend">', res)
+        self.assertNotIn('<div class="input-group-append">', res)
+
     def test_size(self):
         def _test_size(param, klass):
             res = render_template_with_form('{% bootstrap_field form.subject size="' + param + '" %}')

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -325,7 +325,7 @@ class FormTest(TestCase):
         form = TestForm()
         res = render_form(form)
         self.assertIn('<div class="input-group"><div class="input-group-prepend"><span class="input-group-text">before</span></div><input', res)
-        self.assertIn('/><div class="input-group-append"><span class="input-group-text">after</span></div></div>', res)
+        self.assertIn('><div class="input-group-append"><span class="input-group-text">after</span></div></div>', res)
 
     def test_exclude(self):
         form = TestForm()

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -324,8 +324,8 @@ class FormTest(TestCase):
     def test_field_addons(self):
         form = TestForm()
         res = render_form(form)
-        self.assertIn('<div class="input-group"><span class="input-group-addon">before</span><input', res)
-        self.assertIn('/><span class="input-group-addon">after</span></div>', res)
+        self.assertIn('<div class="input-group"><div class="input-group-prepend"><span class="input-group-text">before</span></div><input', res)
+        self.assertIn('/><div class="input-group-append"><span class="input-group-text">after</span></div></div>', res)
 
     def test_exclude(self):
         form = TestForm()
@@ -465,15 +465,15 @@ class FieldTest(TestCase):
     def test_input_group(self):
         res = render_template_with_form('{% bootstrap_field form.subject addon_before="$"  addon_after=".00" %}')
         self.assertIn('class="input-group"', res)
-        self.assertIn('class="input-group-addon">$', res)
-        self.assertIn('class="input-group-addon">.00', res)
+        self.assertIn('class="input-group-prepend"><span class="input-group-text">$', res)
+        self.assertIn('class="input-group-append"><span class="input-group-text">.00', res)
 
     def test_input_group_addon_button(self):
         res = render_template_with_form(
-            '{% bootstrap_field form.subject addon_before="$" addon_before_class="input-group-btn" addon_after=".00" addon_after_class="input-group-btn" %}')  # noqa
+            '{% bootstrap_field form.subject addon_before="$" addon_before_class=None addon_after=".00" addon_after_class=None %}')  # noqa
         self.assertIn('class="input-group"', res)
-        self.assertIn('class="input-group-btn">$', res)
-        self.assertIn('class="input-group-btn">.00', res)
+        self.assertIn('<div class="input-group-prepend">$</div>', res)
+        self.assertIn('<div class="input-group-append">.00</div>', res)
 
     def test_size(self):
         def _test_size(param, klass):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -477,10 +477,10 @@ class FieldTest(TestCase):
 
     def test_input_group_addon_empty(self):
         res = render_template_with_form(
-            '{% bootstrap_field form.subject addon_before=None addon_after="" %}')  # noqa
-        self.assertNotIn('class="input-group"', res)
-        self.assertNotIn('<div class="input-group-prepend">', res)
-        self.assertNotIn('<div class="input-group-append">', res)
+            '{% bootstrap_field form.subject addon_before=None addon_after="after" %}')  # noqa
+        self.assertIn('class="input-group"', res)
+        self.assertNotIn('input-group-prepend', res)
+        self.assertIn('<div class="input-group-append"><span class="input-group-text">after</span></div>', res)
 
     def test_size(self):
         def _test_size(param, klass):


### PR DESCRIPTION
Beta 3 refactored the markup for `input-group`s: https://getbootstrap.com/docs/4.0/migration/#input-groups

In summary:

- Need `input-group-prepend` or `input-group-append` instead of `input-group-addon`.
- Need an inner span to the add-on with the class `input-group-text`, unless you have a button for the add-on, in which case you can omit the span.

So for a add-on before with a button, the html used to be:

```
<span class="input-group-btn">
    <a href="#" class="btn">A button</a>
</span>
```

But now it should be:

```
<span class="input-group-prepend">
    <a href="#" class="btn">A button</a>
</span>
```

And for any other kind of text the html used to be:

```
<span class="input-group-addon">
    Some add-on text
</span>
```

But now it should be:

```
<div class="input-group-prepend">
    <span class="input-group-text">
        <a href="#" class="btn">A button</a>
    </span>
</div>
```

I hope my change makes sense. Basically, you can no longer change the class for `input-group-prepend` or `input-group-append`, but you can change the class for the inner span. Which defaults to `input-group-text`. And if you want to remove the span altogether, like for buttons, you can just set it to `None`.