### PR TITLE
Upgrade bootstap to stable

### DIFF
--- a/bootstrap4/bootstrap.py
+++ b/bootstrap4/bootstrap.py
@@ -10,8 +10,8 @@ from django.conf import settings
 BOOTSTRAP4_DEFAULTS = {
     'base_url': None,  # 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/'
     'css_url': {
-        'href': 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css',
-        'integrity': 'sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy',
+        'href': 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+        'integrity': 'sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm',
         'crossorigin': 'anonymous',
     },
     'theme_url': None,
@@ -26,13 +26,13 @@ BOOTSTRAP4_DEFAULTS = {
         'crossorigin': 'anonymous',
     },
     'popper_url': {
-        'url': 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js',
-        'integrity': 'sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh',
+        'url': 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js',
+        'integrity': 'sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q',
         'crossorigin': 'anonymous',
     },
     'javascript_url': {
-        'url': 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js',
-        'integrity': 'sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4',
+        'url': 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js',
+        'integrity': 'sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl',
         'crossorigin': 'anonymous',
     },
     'javascript_in_head': False,

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -325,7 +325,7 @@ class FormTest(TestCase):
         form = TestForm()
         res = render_form(form)
         self.assertIn('<div class="input-group"><span class="input-group-addon">before</span><input', res)
-        self.assertIn('/><span class="input-group-addon">after</span></div>', res)
+        self.assertIn('><span class="input-group-addon">after</span></div>', res)
 
     def test_exclude(self):
         form = TestForm()


### PR DESCRIPTION
Bootstrap version is currently 4.0.0 stable.

This PR upgrade bootstrap and popper.js versions from [bootstrap documentation](https://getbootstrap.com/docs/4.0/getting-started/introduction/)
