### PR TITLE
Update Docs for bootstrap 4.0.0

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -18,7 +18,7 @@ The ``BOOTSTRAP4`` dict variable contains these settings and defaults:
         'jquery_url': '//code.jquery.com/jquery.min.js',
 
         # The Bootstrap base URL
-        'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/',
+        'base_url': '//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/',
 
         # The complete URL to the Bootstrap CSS file (None means derive it from base_url)
         'css_url': None,


### PR DESCRIPTION
Looks like this update was missed in 4ed40085b291c0b75e484ffc1e414b4c8d4cb152