### PR TITLE
fix rendering of checkbox

### DIFF
--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -334,6 +334,19 @@ class FieldRenderer(BaseRenderer):
             self.add_placeholder_attrs(widget)
             self.add_help_attrs(widget)
 
+    def radio_list_to_class(self, html, klass):
+        classes = add_css_class(klass, self.get_size_class())
+        mapping = [
+            ('<ul', '<div class="{klass}"'.format(klass=classes)),
+            ('</ul>', '</div>'),
+            ('<li>', ''),
+            ('</li>', ''),
+        ]
+        for k, v in mapping:
+            html = html.replace(k, v)
+        return html
+
+
     def list_to_class(self, html, klass):
         classes = add_css_class(klass, self.get_size_class())
         mapping = [
@@ -385,7 +398,7 @@ class FieldRenderer(BaseRenderer):
 
     def post_widget_render(self, html):
         if isinstance(self.widget, RadioSelect):
-            html = self.list_to_class(html, 'radio')
+            html = self.radio_list_to_class(html, 'radio radio-success')
         elif isinstance(self.widget, CheckboxSelectMultiple):
             html = self.list_to_class(html, 'checkbox')
         elif isinstance(self.widget, SelectDateWidget):

--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -346,15 +346,14 @@ class FieldRenderer(BaseRenderer):
             html = html.replace(k, v)
         return html
 
-    def put_inside_label(self, html):
-        content = '{field} {label}'.format(
-            field=html,
-            label=self.field.label,
-        )
-        return render_label(
-            content=mark_safe(content),
-            label_for=self.field.id_for_label,
-            label_title=escape(strip_tags(self.field_help))
+    def add_checkbox_label(self, html):
+        return '{field}{label}'.format(
+                field=html,
+                label=render_label(
+                    content=mark_safe(self.field.label),
+                    label_for=self.field.id_for_label,
+                    label_title=escape(strip_tags(self.field_help))
+                )
         )
 
     def fix_date_select_input(self, html):
@@ -394,7 +393,7 @@ class FieldRenderer(BaseRenderer):
         elif isinstance(self.widget, ClearableFileInput):
             html = self.fix_clearable_file_input(html)
         elif isinstance(self.widget, CheckboxInput):
-            html = self.put_inside_label(html)
+            html = self.add_checkbox_label(html)
         return html
 
     def wrap_widget(self, html):


### PR DESCRIPTION
Hi, 

Currently checkboxes are still rendered in the Bootstrap 3 way: the checkbox input is rendered within the checkbox label. Because of changes in the way checkboxes are handled in Bootstrap 4, checkboxes rendered like this, don't work in Bootstrap 4 compatible themes. 

This pull request changes the rendering to the Bootstrap 4 way.