### PR TITLE
Doc: use the rst syntax for links and update the migration link

### DIFF
--- a/MIGRATE.rst
+++ b/MIGRATE.rst
@@ -5,7 +5,7 @@ Migration
 Below is a list of caveats when migrating from Bootstrap3/django-bootstrap3 to Bootstrap4/django-bootstrap4.
 
 This document only considers the differences between django-bootstrap3 and django-bootstrap4. For the migration
-guide from Bootstrap 3 to 4, please look at the Bootstrap docs, especially the [Migration section](https://v4-alpha.getbootstrap.com/migration/).
+guide from Bootstrap 3 to 4, please look at the Bootstrap docs, especially the `Migration section <https://v4-alpha.getbootstrap.com/migration/>`_.
 
 Icons
 -----

--- a/MIGRATE.rst
+++ b/MIGRATE.rst
@@ -5,7 +5,7 @@ Migration
 Below is a list of caveats when migrating from Bootstrap3/django-bootstrap3 to Bootstrap4/django-bootstrap4.
 
 This document only considers the differences between django-bootstrap3 and django-bootstrap4. For the migration
-guide from Bootstrap 3 to 4, please look at the Bootstrap docs, especially the `Migration section <https://v4-alpha.getbootstrap.com/migration/>`_.
+guide from Bootstrap 3 to 4, please look at the Bootstrap docs, especially the `Migration section <https://getbootstrap.com/docs/4.0/migration/>`_.
 
 Icons
 -----


### PR DESCRIPTION
In the migration doc, the link was in Markdown instead of ReST.
Furthermore, the link pointed to the alpha version of Bootstrap. This is updated to point to the 4.0 doc.