### PR TITLE
Add a new widget: RadioSelectButtonGroup

### DIFF
--- a/bootstrap4/templates/bootstrap4/widgets/radio_select_button_group.html
+++ b/bootstrap4/templates/bootstrap4/widgets/radio_select_button_group.html
@@ -1,0 +1,9 @@
+<div{% if widget.attrs.id %} id="{{ widget.attrs.id }}"{% endif %} class="btn-group btn-group-toggle" data-toggle="buttons">
+    {% for group, options, index in widget.optgroups %}
+        {% for option in options %}
+            <label class="{{ widget.attrs.class|add:' btn btn-outline-primary' }}{% if option.attrs.checked %} active{% endif %}" id="{{ widget.attrs.id }}">
+                <input type="{{ option.type }}" name="{{ option.name }}" id="{{ option.attrs.id }}"{% if option.value != None %} value="{{ option.value|stringformat:'s' }}"{% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}{% if widget.required %} required{% endif %}> {{ option.label }}
+            </label>
+        {% endfor %}
+    {% endfor %}
+</div>

--- a/bootstrap4/widgets.py
+++ b/bootstrap4/widgets.py
@@ -1,0 +1,9 @@
+from django.forms.widgets import RadioSelect
+
+
+class RadioSelectButtonGroup(RadioSelect):
+    """
+    This widget renders a Bootstrap 4 set of buttons horizontally
+    instead of typical radio buttons. Much more mobile friendly.
+    """
+    template_name = 'bootstrap4/widgets/radio_select_button_group.html'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Contents:
    templatetags
    settings
    templates
+   widgets
    contributing
    authors
    history

--- a/docs/widgets.rst
+++ b/docs/widgets.rst
@@ -1,0 +1,25 @@
+=======
+Widgets
+=======
+
+A form widget is available for displaying radio buttons as a Bootstrap 4 button group(https://getbootstrap.com/docs/4.1/components/button-group/).
+
+
+RadioSelectButtonGroup
+~~~~~~~~~~~~~~~~~~~~~~
+
+This renders a form ChoiceField as a Bootstrap 4 button group in the `primary` Bootstrap 4 color.
+
+.. code:: django
+
+    from bootstrap4.widgets import RadioSelectButtonGroup
+
+    class MyForm(forms.Form):
+        media_type = forms.ChoiceField(
+            help_text="Select the order type.",
+            required=True,
+            label="Order Type:",
+            widget=RadioSelectButtonGroup,
+            choices=((1, 'Vinyl'), (2, 'Compact Disc')),
+            initial=1,
+        )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -16,6 +16,7 @@ from bootstrap4.bootstrap import get_bootstrap_setting
 from bootstrap4.exceptions import BootstrapError
 from bootstrap4.text import text_concat, text_value
 from bootstrap4.utils import add_css_class, render_tag, url_replace_param
+from bootstrap4.widgets import RadioSelectButtonGroup
 
 RADIO_CHOICES = (("1", "Radio 1"), ("2", "Radio 2"))
 
@@ -69,6 +70,7 @@ class TestForm(forms.Form):
         widget=forms.CheckboxSelectMultiple,
         help_text="Check as many as you like.",
     )
+    category5 = forms.ChoiceField(widget=RadioSelectButtonGroup, choices=MEDIA_CHOICES)
     addon = forms.CharField(
         widget=forms.TextInput(attrs={"addon_before": "before", "addon_after": "after"})
     )
@@ -335,9 +337,9 @@ class FormTest(TestCase):
         self.assertIn("col-md-3", res)
         self.assertIn("col-md-9", res)
         res = render_template_with_form(
-            '{% bootstrap_form form layout="horizontal" '
-            + 'horizontal_label_class="hlabel" '
-            + 'horizontal_field_class="hfield" %}',
+            '{% bootstrap_form form layout="horizontal" ' +
+            'horizontal_label_class="hlabel" ' +
+            'horizontal_field_class="hfield" %}',
             {"form": form},
         )
         self.assertIn("hlabel", res)
@@ -403,6 +405,13 @@ class FormTest(TestCase):
             '{% bootstrap_form form bound_css_class="" %}', {"form": form}
         )
         self.assertNotIn("bootstrap4-bound", res)
+
+    def test_radio_select_button_group(self):
+        form = TestForm()
+        res = render_template_with_form(
+            '{% bootstrap_form form %}', {"form": form}
+        )
+        self.assertIn('input type="radio" name="category5" id="id_category5_0_0"', res)
 
 
 class FieldTest(TestCase):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -268,10 +268,10 @@ class TemplateTest(TestCase):
 
     def test_bootstrap_template(self):
         res = render_template(
-            '{% extends "bootstrap4/bootstrap4.html" %}'
-            + "{% block bootstrap4_content %}"
-            + "test_bootstrap4_content"
-            + "{% endblock %}"
+            '{% extends "bootstrap4/bootstrap4.html" %}' +
+            "{% block bootstrap4_content %}" +
+            "test_bootstrap4_content" +
+            "{% endblock %}"
         )
         self.assertIn("test_bootstrap4_content", res)
 


### PR DESCRIPTION
This PR adds a widget, `RadioSelectButtonGroup`, which allows display of radio buttons as a mobile friendly Bootstrap4 rendering. Documentation to follow shortly...