### PR TITLE
Fix missing attribute when button having href

### DIFF
--- a/bootstrap4/forms.py
+++ b/bootstrap4/forms.py
@@ -125,6 +125,9 @@ def render_button(
     attrs["class"] = classes
     if href:
         attrs["href"] = href
+        attrs["role"] = "button"
+        if "type" in attrs:
+            del attrs["type"]
         tag = "a"
     else:
         tag = "button"

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -693,8 +693,12 @@ class ButtonTest(TestCase):
         )
         self.assertIn(
             res.strip(),
-            '<a class="btn btn-default btn-lg" href="#">button</a><a href="#" '
-            + 'class="btn btn-lg">button</a>',
+            '<a class="btn btn-default btn-lg" href="#" role="button">button</a>'
+            + '<a class="btn btn-default btn-lg" role="button" href="#" >button</a>'
+            + '<a href="#" class="btn btn-default btn-lg" role="button">button</a>'
+            + '<a href="#" role="button" class="btn btn-default btn-lg">button</a>'
+            + '<a role="button" href="#" class="btn btn-default btn-lg">button</a>'
+            + '<a role="button" class="btn btn-default btn-lg"href="#">button</a>',
         )
 
 


### PR DESCRIPTION
Sample code is

> {% bootstrap_button 'DO_HREF' button_type='button' button_class='btn-primary' href='/SOMEWHERE' %}
