### PR TITLE
Use explicit test matrix in travis conf, adopt django-tables2 testenv naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
 language: python
-sudo: false
-cache: pip
-python:
- - "3.6"
- - "3.5"
- - "3.4"
- - "2.7"
-install: pip install tox-travis
-script: tox
+cache:
+  pip: true
 addons:
   postgresql: 9.6
   apt:
     packages:
      - postgresql-9.6-postgis-2.3
+
+install: pip install tox tox-travis
+script: tox
+
+matrix:
+  include:
+    - { python: 2.7, env: TOXENV=py27-1.11 }
+    - { python: 3.4, env: TOXENV=py34-1.11 }
+    - { python: 3.4, env: TOXENV=py34-2.0 }
+    - { python: 3.5, env: TOXENV=py35-1.11 }
+    - { python: 3.5, env: TOXENV=py35-2.0 }
+    - { python: 3.5, env: TOXENV=py35-2.1 }
+    - { python: 3.5, env: TOXENV=py35-master }
+    - { python: 3.6, env: TOXENV=py36-2.0 }
+    - { python: 3.6, env: TOXENV=py36-2.1 }
+    - { python: 3.6, env: TOXENV=py36-master }
+    - { python: 3.7-dev, env: TOXENV=py37-2.1 }
+    - { python: 3.7-dev, env: TOXENV=py37-master }
+    - { python: 3.6, env: TOXENV=docs }
+    - { python: 3.6, env: TOXENV=flake8 }
+
+  # we allow failures for versions which are not yet released:
+  allow_failures:
+      - env: TOXENV=py35-master
+      - env: TOXENV=py36-master
+      - env: TOXENV=py37-master

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,25 @@
 [tox]
 envlist =
-    {py27}-django{111}
-    {py34}-django{111,20}
-    {py35}-django{111,20,21}
-    {py36}-django{111,20,21}
+    {py27}-{1.11},
+    {py34}-{1.11,2.0},
+    {py35}-{1.11,2.0,2.1,master},
+    {py36}-{1.11,2.0,2.1,master}
+    {py37}-{2.1,master}
     flake8
     docs
+
+[testenv]
+setenv =
+    PYTHONWARNINGS=module::DeprecationWarning
+commands =
+    coverage run --source=bootstrap4 manage.py test -v1 --noinput
+    coverage report -m
+deps =
+    coverage
+    1.11: Django>=1.11,<2.0
+    2.0: Django>=2.0,<2.1
+    2.1: Django==2.1
+    master: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:docs]
 basepython = python
@@ -17,27 +31,9 @@ deps =
 commands = sphinx-build -b html -d _build/doctrees . _build/html
 
 [testenv:flake8]
-basepython = python
-deps =
-    flake8
-commands =
-    flake8
-
-[testenv]
-setenv =
-    PYTHONWARNINGS=module::DeprecationWarning
-commands =
-    coverage run --source=bootstrap4 manage.py test -v1 --noinput
-    coverage report -m
-deps =
-    coverage
-    tox-travis
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django==2.1.0b1
-
-[testenv:djangomaster]
-ignore_outcome = True
+basepython = python3.6
+deps = flake8
+commands = flake8
 
 [flake8]
 ignore = F401,E731,W503
@@ -45,8 +41,7 @@ exclude = .git,.tox,__pycache__
 max-line-length = 120
 
 [travis]
-python =
+python:
     2.7: py27
-    3.4: py34
-    3.5: py35
-    3.6: py36, flake8, docs
+    3.6: py36, docs, flake8
+    3.7-dev: py37


### PR DESCRIPTION
@dyve I was looking into why #71 was failing, and noticed this project still uses `tox-travis`. While that's nice from a declaration/deduplication point of view, it requires one to look into the log to see what environment failed.

In django-tables2, I started defining the testenvs explicitly again, this PR proposes that for django-bootstrap4 too. It also specifies the current stable version of django 2.1, changes the testenv name structure be equal to the one we use in django-tables2.