### PR TITLE
Allow to choose which errors are displayed in form alert block

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 
 Development
 +++++++++++
+- Allow to choose which errors are displayed in form alert block
 - Template tag `bootstrap_field` now allows 3 values for `show_label`: `True`, `False` / `'sr-only'` and `'skip'`. In the case of `False` / `'sr-only'` the label is hidden but present for screen readers. When `show_label` is set to `'skip'`, the label is not generated at all.
 - Fix validation on input groups (#122)
 

--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -159,7 +159,7 @@ class FormRenderer(BaseRenderer):
         self.error_css_class = kwargs.get("error_css_class", None)
         self.required_css_class = kwargs.get("required_css_class", None)
         self.bound_css_class = kwargs.get("bound_css_class", None)
-        self.alert_error_type = kwargs.get("alert_error_type", "all")
+        self.alert_error_type = kwargs.get("alert_error_type", "non_fields")
 
     def render_fields(self):
         rendered_fields = []

--- a/bootstrap4/renderers.py
+++ b/bootstrap4/renderers.py
@@ -159,6 +159,7 @@ class FormRenderer(BaseRenderer):
         self.error_css_class = kwargs.get("error_css_class", None)
         self.required_css_class = kwargs.get("required_css_class", None)
         self.bound_css_class = kwargs.get("bound_css_class", None)
+        self.alert_error_type = kwargs.get("alert_error_type", "all")
 
     def render_fields(self):
         rendered_fields = []
@@ -214,7 +215,7 @@ class FormRenderer(BaseRenderer):
         return ""
 
     def _render(self):
-        return self.render_errors() + self.render_fields()
+        return self.render_errors(self.alert_error_type) + self.render_fields()
 
 
 class FieldRenderer(BaseRenderer):

--- a/bootstrap4/templatetags/bootstrap4.py
+++ b/bootstrap4/templatetags/bootstrap4.py
@@ -443,7 +443,7 @@ def bootstrap_form(*args, **kwargs):
                     * ``'fields'``
                     * ``'non_fields'``
 
-                :default: ``'all'``
+                :default: ``'non_fields'``
 
         See bootstrap_field_ for other arguments
 

--- a/bootstrap4/templatetags/bootstrap4.py
+++ b/bootstrap4/templatetags/bootstrap4.py
@@ -434,6 +434,17 @@ def bootstrap_form(*args, **kwargs):
             A list of field names (comma separated) that should not be rendered
             E.g. exclude=subject,bcc
 
+        alert_error_type
+            Control which type of errors should be rendered in global form alert.
+
+                One of the following values:
+
+                    * ``'all'``
+                    * ``'fields'``
+                    * ``'non_fields'``
+
+                :default: ``'all'``
+
         See bootstrap_field_ for other arguments
 
     **Usage**::

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -409,18 +409,23 @@ class FormTest(TestCase):
     def test_alert_error_type(self):
         form = TestForm({"sender": "sender"})
 
-        # Show all error messages (default config)
-        res = render_template_with_form("{% bootstrap_form form %}", {"form": form})
+        # Show all error messages
+        res = render_template_with_form("{% bootstrap_form form alert_error_type='all' %}", {"form": form})
         html = BeautifulSoup(res, "html.parser")
         errors = list(html.select('.alert-danger')[0].stripped_strings)
         self.assertIn(form.non_field_error_message, errors)
         self.assertIn('This field is required.', errors)
 
-        # Show only non-field error messages
+        # Show only non-field error messages (default config)
         res = render_template_with_form(
             "{% bootstrap_form form alert_error_type='non_fields' %}",
             {"form": form},
         )
+        default = render_template_with_form(
+            "{% bootstrap_form form %}",
+            {"form": form},
+        )
+        self.assertEqual(res, default, 'Default behavior is not the same as showing non-field errors')
         html = BeautifulSoup(res, "html.parser")
         errors = list(html.select('.alert-danger')[0].stripped_strings)
         self.assertIn(form.non_field_error_message, errors)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -80,15 +80,15 @@ class TestForm(forms.Form):
     polygon = gisforms.PointField()
 
     required_css_class = "bootstrap4-req"
+    non_field_error_message = "This is a non field error."
 
     # Set this to allow tests to work properly in Django 1.10+
     # More information, see issue #337
     use_required_attribute = False
 
     def clean(self):
-        cleaned_data = super(TestForm, self).clean()
-        raise forms.ValidationError("This error was added to show the non field errors styling.")
-        return cleaned_data
+        super(TestForm, self).clean()
+        raise forms.ValidationError(self.non_field_error_message)
 
 
 class TestFormWithoutRequiredClass(TestForm):
@@ -405,6 +405,44 @@ class FormTest(TestCase):
         form = TestForm()
         res = render_template_with_form("{% bootstrap_form form %}", {"form": form})
         self.assertIn('input type="radio" name="category5" id="id_category5_0_0"', res)
+
+    def test_alert_error_type(self):
+        form = TestForm({"sender": "sender"})
+
+        # Show all error messages (default config)
+        res = render_template_with_form("{% bootstrap_form form %}", {"form": form})
+        html = BeautifulSoup(res, "html.parser")
+        errors = list(html.select('.alert-danger')[0].stripped_strings)
+        self.assertIn(form.non_field_error_message, errors)
+        self.assertIn('This field is required.', errors)
+
+        # Show only non-field error messages
+        res = render_template_with_form(
+            "{% bootstrap_form form alert_error_type='non_fields' %}",
+            {"form": form},
+        )
+        html = BeautifulSoup(res, "html.parser")
+        errors = list(html.select('.alert-danger')[0].stripped_strings)
+        self.assertIn(form.non_field_error_message, errors)
+        self.assertNotIn('This field is required.', errors)
+
+        # Show only field error messages
+        res = render_template_with_form(
+            "{% bootstrap_form form alert_error_type='fields' %}",
+            {"form": form},
+        )
+        html = BeautifulSoup(res, "html.parser")
+        errors = list(html.select('.alert-danger')[0].stripped_strings)
+        self.assertNotIn(form.non_field_error_message, errors)
+        self.assertIn('This field is required.', errors)
+
+        # Show nothing
+        res = render_template_with_form(
+            "{% bootstrap_form form alert_error_type='none' %}",
+            {"form": form},
+        )
+        html = BeautifulSoup(res, "html.parser")
+        self.assertFalse(html.select('.alert-danger'))
 
 
 class FieldTest(TestCase):


### PR DESCRIPTION
For now, all error messages are displayed in the bootstrap alert when using the `bootstrap_form` model tag, including field errors.

![image](https://user-images.githubusercontent.com/2640288/51996410-8e300f80-24ac-11e9-8a41-4d1aba830835.png)

Field errors appear twice (in alert and below the field), this is not very useful. And for a form with many fields, it can be confusing (which field does this error relate to?).

In this PR, the `alert_error_type` argument is added to the` bootstrap_form` model tag to allow the user to choose whose errors are displayed:
- `all`, the current behavior and the new default behavior (for backward compatibility),
- `fields`, to display only the field errors
- `non_fields`, to show only non-field errors
