### PR TITLE
renderers: Fix bootstrap classes applied to radio and checkbox widgets

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Development
 +++++++++++
 - Template tag `bootstrap_field` now allows 3 values for `show_label`: `True`, `False` / `'sr-only'` and `'skip'`. In the case of `False` / `'sr-only'` the label is hidden but present for screen readers. When `show_label` is set to `'skip'`, the label is not generated at all.
 - Fix validation on input groups (#122)
+- Apply form-check, form-check-label and form-check-input classes to appropriate tags for RadioSelect and CheckboxSelectMultiple widgets
 
 0.0.8 (2019-03-12)
 ++++++++++++++++++

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -404,7 +404,10 @@ class FormTest(TestCase):
     def test_radio_select_button_group(self):
         form = TestForm()
         res = render_template_with_form("{% bootstrap_form form %}", {"form": form})
-        self.assertIn('input type="radio" name="category5" id="id_category5_0_0"', res)
+        self.assertIn(
+            'input class="form-check-input" id="id_category5_0_0" name="category5" required="" type="radio"',
+            res,
+        )
 
 
 class FieldTest(TestCase):
@@ -458,6 +461,58 @@ class FieldTest(TestCase):
         res = render_form_field("password")
         self.assertIn('type="password"', res)
         self.assertIn('placeholder="Password"', res)
+
+    def test_radio_select(self):
+        """Test RadioSelect rendering, because it is special."""
+        res = render_form_field("category1")
+        # strip out newlines and spaces around newlines
+        res = "".join(line.strip() for line in res.split("\n"))
+        res = BeautifulSoup(res, "html.parser")
+        form_group = self._select_one_element(
+            res, ".form-group", "RadioSelect should be rendered inside a .form-group"
+        )
+        radio = self._select_one_element(
+            form_group, ".radio", "There should be a .radio inside .form-group"
+        )
+        self.assertIn(
+            "radio-success",
+            radio["class"],
+            "The radio select should have the class 'radio-success'",
+        )
+        elements = radio.find_all("div", class_="form-check")
+        self.assertIsNotNone(elements, "Radio should have at least one div with class 'form-check'")
+        for idx, form_check in enumerate(elements, start=1):
+            label = form_check.next_element
+            self.assertIsNotNone(label, "The label should be rendered after the form-check div")
+            self.assertEqual(
+                label.name, "label", "After the form-check div there should be a label"
+            )
+            self.assertIn(
+                "form-check-label",
+                label["class"],
+                "The label should have the class 'form-check-label'",
+            )
+            self.assertEqual(
+                "Radio {idx}".format(idx=idx),
+                label.text,
+                "The label should have text 'Radio {idx}'".format(idx=idx),
+            )
+            input_ = label.next_element
+            self.assertIsNotNone(input_, "The input should be rendered after the label")
+            self.assertEqual(input_.name, "input", "After the label there should be an input")
+            self.assertIn(
+                "form-check-input",
+                input_["class"],
+                "The input should have the class 'form-check-input'",
+            )
+            self.assertEqual(
+                str(idx), input_["value"], "The input should have value '{idx}'".format(idx=idx)
+            )
+            self.assertEqual(
+                label["for"],
+                input_["id"],
+                "The for attribute of the label should be the id of the radio input",
+            )
 
     def test_checkbox(self):
         """Test Checkbox rendering, because it is special."""


### PR DESCRIPTION
According to [bootstrap4 inputs doc](https://www.w3schools.com/bootstrap4/bootstrap_forms_inputs.asp), there's no difference between checkboxes and radio buttons. However the current implementation made a distinction, and was missing some classes and enclosing div. A radio button widget was rendered with choices side-by-side instead of on top of each other for example.

This commit fixes this. Here's the `category1` form field from `TestForm` rendered before the changes:

```html
<div class="form-group bootstrap4-req">                                                  
 <label for="id_category1_0">                                                            
  Category1                                                                              
 </label>                                                                                
 <div class="radio radio-success" id="id_category1">                                     
  <label for="id_category1_0">                                                           
   <input class="" id="id_category1_0" name="category1" title="" type="radio" value="1"/>
   Radio 1                                                                               
  </label>                                                                               
  <label for="id_category1_1">                                                           
   <input class="" id="id_category1_1" name="category1" title="" type="radio" value="2"/>
   Radio 2                                                                               
  </label>                                                                               
 </div>                                                                                  
</div>                                                                                   
```

and here it is after:

```html
<div class="form-group bootstrap4-req">                                                                   
 <label for="id_category1_0">                                                                             
  Category1                                                                                               
 </label>                                                                                                 
 <div class="radio radio-success" id="id_category1">                                                      
  <div class="form-check">                                                                                
   <label class="form-check-label" for="id_category1_0">                                                  
    <input class="form-check-input" id="id_category1_0" name="category1" title="" type="radio" value="1"/>
    Radio 1                                                                                               
   </label>                                                                                               
  </div>                                                                                                  
  <div class="form-check">                                                                                
   <label class="form-check-label" for="id_category1_1">                                                  
    <input class="form-check-input" id="id_category1_1" name="category1" title="" type="radio" value="2"/>
    Radio 2                                                                                               
   </label>                                                                                               
  </div>                                                                                                  
 </div>                                                                                                   
</div>                                                                                                    
```

Notice the new `form-check-label` and `form-check-input` classes, as well as the enclosing `div class="form-check"` element.

I introduced the use of BeautifulSoup in `renderers.py` as it's much easier to edit the tags attributes with it. I think it'd be nice to use throughout the whole file, but that would be way out of scope for this PR :)