### PR TITLE
Use six instead of django.utils.six

### DIFF
--- a/bootstrap4/templatetags/bootstrap4.py
+++ b/bootstrap4/templatetags/bootstrap4.py
@@ -3,12 +3,12 @@ from __future__ import unicode_literals
 
 from math import floor
 
+import six
 from django import template
 from django.contrib.messages import constants as message_constants
 from django.template import Context
-from django.utils import six
 from django.utils.safestring import mark_safe
-from django.utils.six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from ..bootstrap import (
     css_url,

--- a/bootstrap4/utils.py
+++ b/bootstrap4/utils.py
@@ -3,15 +3,15 @@ from __future__ import unicode_literals
 
 import re
 
+import six
 from django.forms.utils import flatatt
 from django.template import Variable, VariableDoesNotExist
 from django.template.base import FilterExpression, TemplateSyntaxError, kwarg_re
 from django.template.loader import get_template
-from django.utils import six
 from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from .text import text_value
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,9 @@ setup(
     url="https://github.com/zostera/django-bootstrap4",
     packages=["bootstrap4"],
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        "six"
+    ],
     license="Apache License 2.0",
     zip_safe=False,
     keywords="django-bootstrap4",


### PR DESCRIPTION
The upcoming Django 3.0 will drop django.utils.six completely.
Closes #153