### PR TITLE
Only display non-field errors in form alert block

### DIFF
--- a/src/bootstrap4/renderers.py
+++ b/src/bootstrap4/renderers.py
@@ -147,6 +147,7 @@ class FormRenderer(BaseRenderer):
         self.error_css_class = kwargs.get("error_css_class", None)
         self.required_css_class = kwargs.get("required_css_class", None)
         self.bound_css_class = kwargs.get("bound_css_class", None)
+        self.alert_error_type = kwargs.get("alert_error_type", "non_fields")
 
     def render_fields(self):
         rendered_fields = []
@@ -197,7 +198,7 @@ class FormRenderer(BaseRenderer):
         return ""
 
     def _render(self):
-        return self.render_errors() + self.render_fields()
+        return self.render_errors(self.alert_error_type) + self.render_fields()
 
 
 class FieldRenderer(BaseRenderer):

--- a/src/bootstrap4/templatetags/bootstrap4.py
+++ b/src/bootstrap4/templatetags/bootstrap4.py
@@ -428,6 +428,17 @@ def bootstrap_form(*args, **kwargs):
             A list of field names (comma separated) that should not be rendered
             E.g. exclude=subject,bcc
 
+        alert_error_type
+            Control which type of errors should be rendered in global form alert.
+
+                One of the following values:
+
+                    * ``'all'``
+                    * ``'fields'``
+                    * ``'non_fields'``
+
+                :default: ``'non_fields'``
+
         See bootstrap_field_ for other arguments
 
     **Usage**::


### PR DESCRIPTION
Rebased the fix from #130, thanks @fbochu