### PR TITLE
Honor the `form_group_class` parameter in the `buttons` tag

### DIFF
--- a/src/bootstrap4/templatetags/bootstrap4.py
+++ b/src/bootstrap4/templatetags/bootstrap4.py
@@ -812,8 +812,7 @@ class ButtonsNode(template.Node):
         buttons = " ".join(buttons) + self.nodelist.render(context)
         output_kwargs.update({"label": None, "field": buttons})
         css_class = output_kwargs.pop("form_group_class", "form-group")
-        output = render_form_group(render_field_and_label(**output_kwargs),
-                                  css_class=css_class)
+        output = render_form_group(render_field_and_label(**output_kwargs), css_class=css_class)
         if self.asvar:
             context[self.asvar] = output
             return ""


### PR DESCRIPTION
The `form_group_class` parameter was being ignored in the `buttons` tag. This small patch fixes it.