### PR TITLE
Add missing dependency on BeautifulSoup4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    install_requires=[],
+    install_requires=["beautifulsoup4"],
     license="Apache License 2.0",
     zip_safe=False,
     keywords="django-bootstrap4",


### PR DESCRIPTION
It looks like this package used to only rely on Beautiful Soup for testing, but its now used in the renderer too. However this wasn't called out in the setup.py `install_requires` field.
This was preventing installing with pip.

I'm not 100% up to speed with python packaging, so apologies if the dependency is supposed to be declared elsewhere. Happy to redo the PR another way if it's appropriate.