### PR TITLE
Replace force_text with force_str

### DIFF
--- a/src/bootstrap4/text.py
+++ b/src/bootstrap4/text.py
@@ -1,14 +1,11 @@
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_str
 
 
 def text_value(value):
     """Force a value to text, render None as an empty string."""
     if value is None:
         return ""
-    return force_text(value)
+    return force_str(value)
 
 
 def text_concat(*args, **kwargs):


### PR DESCRIPTION
Since Django 2.0, force_text and force_str are aliases. They are different only for python2, which is not supported anymore with Django 2.0 and later. force_text is deprecated with Django 3.0. Since bootstrap4 only supports Django 2.1 and later (and therefore only python3), force_text can be replaced by force_str with no issues to avoid deprecation warnings with Django 3.0