### PR TITLE
Removed `.alert-link` CSS class from form_errors.html

### DIFF
--- a/src/bootstrap4/templates/bootstrap4/form_errors.html
+++ b/src/bootstrap4/templates/bootstrap4/form_errors.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="alert alert-danger alert-dismissible alert-link" role="alert">
+<div class="alert alert-danger alert-dismissible" role="alert">
     <button class="close" type="button" data-dismiss="alert" aria-label="{% trans 'close' %}">&#215;</button>
     {% for error in errors %}
         {{ error }}{% if not forloop.last %}<br>{% endif %}


### PR DESCRIPTION
I believe [`.alert-link`](https://getbootstrap.com/docs/4.5/components/alerts/#link-color) is intended to be used for hyperlinks and shouldn't be applied to regular text.

I know I can override this template in my project but I think others would benefit from this change as well.

**Before**
![image](https://user-images.githubusercontent.com/484429/87840490-1ea70f00-c85d-11ea-94ba-f6e1c12371d9.png)

**After**
![image](https://user-images.githubusercontent.com/484429/87840470-0f27c600-c85d-11ea-92dd-cac11055a89c.png)

PS - I'm enjoying the project so far. It's making things *so* much nicer than they would otherwise be. Thanks!