### PR TITLE
requirements: Accept importlib-metadata 2.x.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -221,7 +221,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.7.0"
+version = "2.0.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -590,7 +590,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 docs = ["sphinx", "sphinx_rtd_theme", "m2r"]
 
 [metadata]
-content-hash = "8411cb2a6e43f1683168d7f27efe87310a9621c80fad7c443c34aceb84feef8d"
+content-hash = "e2f85acb94c39f021fcaff10914ac999e054c506f7985c7ece75cdfdd617719f"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -703,8 +703,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
-    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
+    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ include = ["LICENSE"]
 [tool.poetry.dependencies]
 python = "^3.6"
 django = "^2.2 || ^3.0"
-importlib-metadata = { version = "^1.5.0", python = "<3.8", optional = true }
+importlib-metadata = { version = "<3", python = "<3.8", optional = true }
 beautifulsoup4 = "^4.8.0"
 
 # docs


### PR DESCRIPTION
A new version of importlib-metadata (2.0.0) has been released a few
days ago. Its changelog [1] mentions that the only change is the
removal of `importlib_metadata.__version__`, which is not used by
django-bootstrap4. So we can safely accept this version.

The current pinning (^1.5.0) is problematic because projects that
depend on django-bootstrap4 may require importlib-metadata with a more
laxist pinning (or no pinning at all).

[1] https://importlib-metadata.readthedocs.io/en/latest/changelog%20%28links%29.html#v2-0-0

---

I am not familiar with Poetry. I updated `pyproject.toml` and then ran `poetry update importlib-metadat`. I hope it's fine.