### PR TITLE
Removed extra <br> in FileInput fields when using horizontal layout

### DIFF
--- a/src/bootstrap4/renderers.py
+++ b/src/bootstrap4/renderers.py
@@ -360,6 +360,9 @@ class FieldRenderer(BaseRenderer):
         return '<div class="row bootstrap4-multi-input">{html}</div>'.format(html=html)
 
     def fix_file_input_label(self, html):
+        if self.layout == "horizontal":
+            return html
+        
         html = "<br>" + html
         return html
 


### PR DESCRIPTION
When using horizontal layouts, the extra <br> is not needed for file inputs.