### PR TITLE
Includes tip for "bootstrap_pagination" on how to preserve query strings

### DIFF
--- a/src/bootstrap4/templatetags/bootstrap4.py
+++ b/src/bootstrap4/templatetags/bootstrap4.py
@@ -911,6 +911,12 @@ def bootstrap_pagination(page, **kwargs):
     **Example**::
 
         {% bootstrap_pagination lines url="/pagination?page=1" size="large" %}
+    
+    **Tip**::
+    
+      If you want to repeat the query string arguments in subsequent pagination links, use the "extra" parameter with "request.GET.urlencode":
+        
+        {% bootstrap_pagination page_obj extra=request.GET.urlencode %}
     """
     pagination_kwargs = kwargs.copy()
     pagination_kwargs["page"] = page


### PR DESCRIPTION
Adds a tip to repeat query string arguments in pagination links, useful for search result pages, for example. 

Reference: https://www.pedaldrivenprogramming.com/2016/11/preserve-get-parameters-using-django-bootstrap3-pagination/