### PR TITLE
Include JS bundle instead of separate script

### DIFF
--- a/src/bootstrap4/bootstrap.py
+++ b/src/bootstrap4/bootstrap.py
@@ -9,8 +9,8 @@ BOOTSTRAP4_DEFAULTS = {
         "crossorigin": "anonymous",
     },
     "javascript_url": {
-        "url": "https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js",
-        "integrity": "sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF",
+        "url": "https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js",
+        "integrity": "sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns",
         "crossorigin": "anonymous",
     },
     "theme_url": None,


### PR DESCRIPTION
This actually includes the JS bundle in the template tag as per the 3.0.0 changelog.

```
   Use bundled Bootstrap JavaScript, no need for separate popper.js.*
```