### PR TITLE
Fix faulty example code

### DIFF
--- a/src/bootstrap4/templatetags/bootstrap4.py
+++ b/src/bootstrap4/templatetags/bootstrap4.py
@@ -723,7 +723,7 @@ def bootstrap_alert(content, alert_type="info", dismissible=True):
 
     **Example**::
 
-        {% bootstrap_alert "Something went wrong" alert_type='error' %}
+        {% bootstrap_alert "Something went wrong" alert_type='danger' %}
     """
     return render_alert(content, alert_type, dismissible)
 


### PR DESCRIPTION
I copy&pasted this line and wondered why my alert has no colored background. Well, then I realized that there is no `alert_type='error'` like given in the example code.