### PR TITLE
Use re_path instead of url

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from app.views import (
     DefaultFormByFieldView,


### PR DESCRIPTION
The reason for the error is explained at https://stackoverflow.com/questions/70319606/importerror-cannot-import-name-url-from-django-conf-urls-after-upgrading-to

This Pull Request fixes https://github.com/zostera/django-bootstrap4/issues/416