### PR TITLE
allow later importlib-metadata versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     install_requires=[
         "Django>=2.2",
         "beautifulsoup4>=4.8.0",
-        'importlib-metadata<3; python_version<"3.8"',
+        'importlib-metadata>=1.4; python_version<"3.8"',
     ],
 )


### PR DESCRIPTION
Old version limited upgradability and made library incompatible with a lot of other libraries

Resolves #380 