### PR TITLE
Fix templates folder in package release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## In development
+
+- Fix templates folder inside package (#662).
+
 ## 23.3 (2023-12-24)
 
 - Use ruff instead of black for formatting (#653).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/bootstrap4/templates/bootstrap4 *.html


### PR DESCRIPTION
This PR attempts to fix issue https://github.com/zostera/django-bootstrap4/issues/661

Here is the [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data) that I follow to include  `templates` folder

These html files were not included  in the previous release (23.3) because they are not pure Python files.