### PR TITLE
Fix CheckboxSelectMultiple on Django>4

### DIFF
--- a/src/bootstrap4/renderers.py
+++ b/src/bootstrap4/renderers.py
@@ -372,10 +372,10 @@ class FieldRenderer(BaseRenderer):
         return html
 
     def post_widget_render(self, html):
-        if isinstance(self.widget, RadioSelect):
-            html = self.list_to_class(html, "radio radio-success")
-        elif isinstance(self.widget, CheckboxSelectMultiple):
+        if isinstance(self.widget, CheckboxSelectMultiple):
             html = self.list_to_class(html, "checkbox")
+        elif isinstance(self.widget, RadioSelect):
+            html = self.list_to_class(html, "radio radio-success")
         elif isinstance(self.widget, SelectDateWidget):
             html = self.fix_date_select_input(html)
         elif isinstance(self.widget, CheckboxInput):


### PR DESCRIPTION
On Django 4.2 CheckboxSelectMultiple is [subclass of RadioSelect](https://github.com/django/django/blob/stable/4.2.x/django/forms/widgets.py#L862).

Therefore [this part](https://github.com/zostera/django-bootstrap4/blob/main/src/bootstrap4/renderers.py#L377) is unreachable.
The easyest fix is swap `if`.

