### PR TITLE
Ignore pyproject.toml.orig in check-manifest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,4 @@ source-include = [
 ]
 
 [tool.check-manifest]
-ignore = ["uv.lock"]
+ignore = ["uv.lock", "pyproject.toml.orig"]


### PR DESCRIPTION
## Summary
- `uv_build` bumped past 0.12.0 (#869), which now writes a `pyproject.toml.orig` backup into the sdist
- `check-manifest` flags that file as untracked, failing the `build` CI job — same root cause already fixed in zostera/django-bootstrap3 and zostera/django-marina, blocking #870 and #871 here too

## Test plan
- [x] `uv build` + `uvx check-manifest` pass locally