### PR TITLE
Fix release process doc: version bump via PR, not direct push to main

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -38,9 +38,12 @@ monitor here under normal circumstances; only revisit if upstream unexpectedly c
 
 ## Release process
 
-1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
-2. Commit and push to `main`
+1. On a release branch, update `CHANGELOG.md` and bump `version` in `pyproject.toml`; open a PR and merge it
+2. Check out and pull `main`
 3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
 4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+
+`main` is protected — direct pushes are rejected (or bypass branch protection, which is worse). Always land the
+version bump through a PR like any other change.
 
 `just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,4 +124,4 @@ source-include = [
 ]
 
 [tool.check-manifest]
-ignore = ["uv.lock"]
+ignore = ["uv.lock", "pyproject.toml.orig"]


### PR DESCRIPTION
## Summary
- MAINTAINING.md's release process said "commit and push to main" for the version-bump step
- `main` is protected here too — same bug already fixed in zostera/django-bootstrap3#1135 and zostera/django-marina#665
- Fixes the doc to route the version bump through a release branch + PR

## Test plan
- [x] Docs-only change